### PR TITLE
FEAT: Update Vite build path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,9 @@ COPY client/package*.json ./
 
 RUN npm ci
 
-COPY client/ .
+COPY client/ ./client
 
-RUN npm run build
+RUN cd client && npm run build
 
 FROM debian:bookworm-slim
 
@@ -33,7 +33,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
 COPY server/internal/database/migrations ./internal/database/migrations
 
 COPY --from=builder-backend /app/liquor-locker .
-COPY --from=builder-frontend /app/dist /app/dist
+COPY --from=builder-frontend /app/server/dist /app/dist
 
 RUN mkdir -p internal/database/data
 

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "client",
 	"private": true,
-	"version": "2.1.1",
+	"version": "2.1.2",
 	"type": "module",
 	"scripts": {
 		"dev": "vite",

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -15,4 +15,8 @@ export default defineConfig({
 	define: {
 		__APP_VERSION__: JSON.stringify(pkg.version),
 	},
+	build: {
+		outDir: path.resolve(__dirname, "../server/dist"),
+		emptyOutDir: true,
+	},
 });


### PR DESCRIPTION
This updates Vite's build path to `server/dist` which makes local development easier, as this is where the Go backend serves the frontend from